### PR TITLE
Proposed changes to builder enhancements

### DIFF
--- a/pkg/apps/qdrouterd/deployment/interconnect.go
+++ b/pkg/apps/qdrouterd/deployment/interconnect.go
@@ -53,7 +53,7 @@ func CreateInterconnect(c framework.ContextData, size int32, fn ...InterconnectC
 		Spec: v1alpha1.InterconnectSpec{
 			DeploymentPlan: v1alpha1.DeploymentPlanType{
 				Size:      size,
-				Image:     operator.Image(),
+				Image:     "quay.io/interconnectedcloud/qdrouterd",
 				Role:      "interior",
 				Placement: "Any",
 			},

--- a/pkg/framework/framework.go
+++ b/pkg/framework/framework.go
@@ -203,6 +203,8 @@ func (f *Framework) BeforeEach(contexts ...string) {
 		if f.builders == nil || len(f.builders) == 0 {
 			// populate builders with default values
 			for _, builder := range operators.SupportedOperators {
+				builder.NewBuilder(restConfig)
+				builder.WithNamespace(namespace.GetName())
 				f.builders = append(f.builders, builder)
 			}
 		}

--- a/pkg/framework/operators/baseoperator.go
+++ b/pkg/framework/operators/baseoperator.go
@@ -29,7 +29,7 @@ type BaseOperatorBuilder struct {
 	operatorName string
 	keepCdrs     bool
 	apiVersion   string
-	canEdit      bool
+	finalized    bool
 }
 
 type BaseOperator struct {
@@ -61,13 +61,16 @@ type DefinitionStruct struct {
 
 func (b *BaseOperatorBuilder) NewBuilder(restConfig *rest.Config) OperatorSetupBuilder {
 	b.restConfig = restConfig
-	b.canEdit = true
 	return b
 }
 
 func (b *BaseOperatorBuilder) WithNamespace(namespace string) OperatorSetupBuilder {
-	b.namespace = namespace
-	return b
+	if !b.finalized {
+		b.namespace = namespace
+		return b
+	} else {
+		panic(fmt.Errorf("can't edit operator builder post-finalization"))
+	}
 }
 
 func (b *BaseOperatorBuilder) OperatorType() OperatorType {
@@ -75,17 +78,8 @@ func (b *BaseOperatorBuilder) OperatorType() OperatorType {
 	panic("implement me")
 }
 
-//func (b *BaseOperatorBuilder) WithNamespace(namespace string) *BaseOperatorBuilder {
-//	if (b.canEdit) {
-//		b.namespace = namespace
-//		return b
-//	} else {
-//		panic(fmt.Errorf("can't edit operator builder post-finalization"))
-//	}
-//}
-//
 func (b *BaseOperatorBuilder) WithImage(image string) OperatorSetupBuilder {
-	if (b.canEdit) {
+	if !b.finalized {
 		b.image = image
 		return b
 	} else {
@@ -94,7 +88,7 @@ func (b *BaseOperatorBuilder) WithImage(image string) OperatorSetupBuilder {
 }
 
 func (b *BaseOperatorBuilder) WithYamls(yamls []string) OperatorSetupBuilder {
-	if (b.canEdit) {
+	if !b.finalized {
 		b.yamls = yamls
 		return b
 	} else {
@@ -103,7 +97,7 @@ func (b *BaseOperatorBuilder) WithYamls(yamls []string) OperatorSetupBuilder {
 }
 
 func (b *BaseOperatorBuilder) AddYaml(yaml string) OperatorSetupBuilder {
-	if (b.canEdit) {
+	if !b.finalized {
 		b.yamls = append(b.yamls, yaml)
 		return b
 	} else {
@@ -112,7 +106,7 @@ func (b *BaseOperatorBuilder) AddYaml(yaml string) OperatorSetupBuilder {
 }
 
 func (b *BaseOperatorBuilder) WithOperatorName(name string) OperatorSetupBuilder {
-	if (b.canEdit) {
+	if !b.finalized {
 		b.operatorName = name
 		return b
 	} else {
@@ -121,7 +115,7 @@ func (b *BaseOperatorBuilder) WithOperatorName(name string) OperatorSetupBuilder
 }
 
 func (b *BaseOperatorBuilder) KeepCdr(keepCdrs bool) OperatorSetupBuilder {
-	if (b.canEdit) {
+	if !b.finalized {
 		b.keepCdrs = keepCdrs
 		return b
 	} else {
@@ -130,7 +124,7 @@ func (b *BaseOperatorBuilder) KeepCdr(keepCdrs bool) OperatorSetupBuilder {
 }
 
 func (b *BaseOperatorBuilder) WithApiVersion(apiVersion string) OperatorSetupBuilder {
-	if (b.canEdit) {
+	if !b.finalized {
 		b.apiVersion = apiVersion
 		return b
 	} else {
@@ -139,7 +133,7 @@ func (b *BaseOperatorBuilder) WithApiVersion(apiVersion string) OperatorSetupBui
 }
 
 func (b *BaseOperatorBuilder) Finalize() *BaseOperatorBuilder {
-	b.canEdit = false
+	b.finalized = true
 	return b
 }
 

--- a/pkg/framework/operators/operator.go
+++ b/pkg/framework/operators/operator.go
@@ -1,6 +1,16 @@
 package operators
 
+import "k8s.io/client-go/rest"
+
 type OperatorSetupBuilder interface {
+	NewBuilder(restConfig *rest.Config) OperatorSetupBuilder
+	WithNamespace(namespace string) OperatorSetupBuilder
+	WithImage(image string) OperatorSetupBuilder
+	WithYamls(yamls []string) OperatorSetupBuilder
+	AddYaml(yaml string) OperatorSetupBuilder
+	WithOperatorName(name string) OperatorSetupBuilder
+	KeepCdr(keepCdrs bool) OperatorSetupBuilder
+	WithApiVersion(apiVersion string) OperatorSetupBuilder
 	Build() (OperatorAccessor, error)
 	OperatorType() OperatorType
 }

--- a/pkg/framework/operators/qdroperator.go
+++ b/pkg/framework/operators/qdroperator.go
@@ -8,10 +8,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextv1b1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
-	apiextension "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	clientset "k8s.io/client-go/kubernetes"
 	"strings"
 )
 
@@ -27,28 +25,11 @@ func (q *QdrOperatorBuilder) Build() (OperatorAccessor, error) {
 		return qdr, err
 	}
 
-	qdr.namespace = q.namespace
-	qdr.restConfig = q.restConfig
-
 	// initializing qdrclient
 	if client, err := qdrclientset.NewForConfig(q.restConfig); err != nil {
 		return qdr, err
 	} else {
 		qdr.qdrClient = client
-	}
-
-	// initializing kubeclient
-	if client, err := clientset.NewForConfig(q.restConfig); err != nil {
-		return qdr, err
-	} else {
-		qdr.kubeClient = client
-	}
-
-	// initializing extclient
-	if client, err := apiextension.NewForConfig(q.restConfig); err != nil {
-		return qdr, err
-	} else {
-		qdr.extClient = client
 	}
 
 	return qdr, nil

--- a/pkg/framework/operators/qdroperator.go
+++ b/pkg/framework/operators/qdroperator.go
@@ -4,13 +4,8 @@ import (
 	"fmt"
 	qdrclientset "github.com/interconnectedcloud/qdr-operator/pkg/client/clientset/versioned"
 	"github.com/rh-messaging/shipshape/pkg/framework/log"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
-	apiextv1b1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"strings"
 )
 
 // Reusing BaseOperatorBuilder implementation and adding
@@ -32,6 +27,20 @@ func (q *QdrOperatorBuilder) Build() (OperatorAccessor, error) {
 		qdr.qdrClient = client
 	}
 
+	// Setting up the defaults
+	baseImportPath := "https://raw.githubusercontent.com/interconnectedcloud/qdr-operator/master/deploy/"
+	if qdr.yamls == nil {
+		qdr.yamls = []string{
+			baseImportPath + "service_account.yaml",
+			baseImportPath + "role.yaml",
+			baseImportPath + "role_binding.yaml",
+			baseImportPath + "cluster_role.yaml",
+			baseImportPath + "cluster_role_binding.yaml",
+			baseImportPath + "crds/interconnectedcloud_v1alpha1_interconnect_crd.yaml",
+			baseImportPath + "operator.yaml",
+		}
+	}
+
 	return qdr, nil
 }
 
@@ -49,46 +58,13 @@ func (q *QdrOperator) Namespace() string {
 }
 
 func (q *QdrOperator) Setup() error {
-	log.Logf("Setting up Service Account")
-	if err := q.SetupServiceAccount(); err != nil {
-		return err
-	}
-
-	log.Logf("Setting up Role")
-	if err := q.SetupRole(); err != nil {
-		return err
-	}
-
-	log.Logf("Setting up Cluster Role")
-	if err := q.SetupClusterRole(); err != nil && !strings.Contains(err.Error(), "already exists") {
-		return err
-	}
-
-	log.Logf("Setting up Role Binding")
-	if err := q.SetupRoleBinding(); err != nil {
-		return err
-	}
-
-	log.Logf("Setting up Cluster Role Binding")
-	if err := q.SetupClusterRoleBinding(); err != nil && !strings.Contains(err.Error(), "already exists") {
-		return err
-	}
-
-	log.Logf("Setting up CRD")
-	if err := q.SetupCRD(); err != nil && !strings.Contains(err.Error(), "already exists") {
-		return err
-	} else if err != nil {
-		// In case CRD already exists, do not remove on clean up (to preserve original state)
-		q.keepCRD = true
-
-	}
-
-	log.Logf("Setting up Operator Deployment")
-	if err := q.SetupDeployment(); err != nil {
+	log.Logf("Setting up from YAMLs")
+	if err := q.SetupYamls(); err != nil {
 		return err
 	}
 
 	return nil
+
 }
 
 func (q *QdrOperator) TeardownEach() error {
@@ -160,240 +136,6 @@ func (q *QdrOperator) Name() string {
 
 func (q *QdrOperator) Interface() interface{} {
 	return q.qdrClient
-}
-
-func (q *QdrOperator) SetupServiceAccount() error {
-	sa := &corev1.ServiceAccount{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: q.Name(),
-		},
-	}
-	_, err := q.kubeClient.CoreV1().ServiceAccounts(q.Namespace()).Create(sa)
-	if err != nil {
-		return fmt.Errorf("create %s service account failed: %v", q.Name(), err)
-	}
-	return nil
-}
-
-func (q *QdrOperator) SetupRole() error {
-	role := &rbacv1.Role{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: q.Name(),
-		},
-		Rules: []rbacv1.PolicyRule{
-			{
-				APIGroups: []string{""},
-				Resources: []string{"pods", "services", "serviceaccounts", "endpoints", "persistentvolumeclaims", "events", "configmaps", "secrets"},
-				Verbs:     []string{"*"},
-			},
-			{
-				APIGroups: []string{"rbac.authorization.k8s.io"},
-				Resources: []string{"rolebindings", "roles"},
-				Verbs:     []string{"get", "list", "watch", "create", "delete"},
-			},
-			{
-				APIGroups: []string{"extensions"},
-				Resources: []string{"ingresses"},
-				Verbs:     []string{"get", "list", "watch", "create", "delete"},
-			},
-			{
-				APIGroups: []string{""},
-				Resources: []string{"namespaces"},
-				Verbs:     []string{"get"},
-			},
-			{
-				APIGroups: []string{"apps"},
-				Resources: []string{"deployments", "daemonsets", "replicasets", "statefulsets"},
-				Verbs:     []string{"*"},
-			},
-			{
-				APIGroups: []string{"certmanager.k8s.io"},
-				Resources: []string{"issuers", "certificates"},
-				Verbs:     []string{"get", "list", "watch", "create", "delete"},
-			},
-			{
-				APIGroups: []string{"monitoring.coreos.com"},
-				Resources: []string{"servicemonitors"},
-				Verbs:     []string{"get", "create"},
-			},
-			{
-				APIGroups: []string{"route.openshift.io"},
-				Resources: []string{"routes", "routes/custom-host", "routes/status"},
-				Verbs:     []string{"get", "list", "watch", "create", "delete"},
-			},
-			{
-				APIGroups: []string{"interconnectedcloud.github.io"},
-				Resources: []string{"*"},
-				Verbs:     []string{"*"},
-			},
-		},
-	}
-	_, err := q.kubeClient.RbacV1().Roles(q.Namespace()).Create(role)
-	if err != nil {
-		return fmt.Errorf("create qdr-operator role failed: %v", err)
-	}
-	return nil
-}
-
-func (q *QdrOperator) SetupClusterRole() error {
-	crole := &rbacv1.ClusterRole{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: q.Name(),
-		},
-		Rules: []rbacv1.PolicyRule{
-			{
-				APIGroups: []string{"apiextensions.k8s.io"},
-				Resources: []string{"customresourcedefinitions"},
-				Verbs:     []string{"get", "list"},
-			},
-		},
-	}
-	_, err := q.kubeClient.RbacV1().ClusterRoles().Create(crole)
-	if err != nil {
-		return fmt.Errorf("create qdr-operator cluster role failed: %v", err)
-	}
-	return nil
-}
-
-func (q *QdrOperator) SetupRoleBinding() error {
-	rb := &rbacv1.RoleBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: q.Name(),
-		},
-		RoleRef: rbacv1.RoleRef{
-			APIGroup: "rbac.authorization.k8s.io",
-			Kind:     "Role",
-			Name:     q.Name(),
-		},
-		Subjects: []rbacv1.Subject{
-			{
-				APIGroup:  "",
-				Kind:      "ServiceAccount",
-				Name:      q.Name(),
-				Namespace: q.Namespace(),
-			},
-		},
-	}
-	_, err := q.kubeClient.RbacV1().RoleBindings(q.Namespace()).Create(rb)
-	if err != nil {
-		return fmt.Errorf("create qdr-operator role binding failed: %v", err)
-	}
-	return nil
-}
-
-func (q *QdrOperator) SetupClusterRoleBinding() error {
-	crb := &rbacv1.ClusterRoleBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: q.Name(),
-		},
-		RoleRef: rbacv1.RoleRef{
-			APIGroup: "rbac.authorization.k8s.io",
-			Kind:     "ClusterRole",
-			Name:     q.Name(),
-		},
-		Subjects: []rbacv1.Subject{
-			{
-				APIGroup:  "",
-				Kind:      "ServiceAccount",
-				Name:      q.Name(),
-				Namespace: q.Namespace(),
-			},
-		},
-	}
-	_, err := q.kubeClient.RbacV1().ClusterRoleBindings().Create(crb)
-	if err != nil {
-		return fmt.Errorf("create qdr-operator cluster role binding failed: %v", err)
-	}
-	return nil
-}
-
-func (q *QdrOperator) SetupCRD() error {
-	for _, crdName := range q.CRDNames() {
-		crd := &apiextv1b1.CustomResourceDefinition{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: crdName,
-			},
-			Spec: apiextv1b1.CustomResourceDefinitionSpec{
-				Group: q.GroupName(),
-				Names: apiextv1b1.CustomResourceDefinitionNames{
-					Kind:     "Interconnect",
-					ListKind: "InterconnectList",
-					Plural:   "interconnects",
-					Singular: "interconnect",
-				},
-				Scope:   "Namespaced",
-				Version: q.APIVersion(),
-			},
-		}
-		_, err := q.extClient.ApiextensionsV1beta1().CustomResourceDefinitions().Create(crd)
-		if err != nil {
-			return fmt.Errorf("create qdr-operator crd failed: %v", err)
-		}
-	}
-	return nil
-}
-
-func (q *QdrOperator) SetupDeployment() error {
-	dep := &appsv1.Deployment{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "apps/v1",
-			Kind:       "Deployment",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: q.Name(),
-		},
-		Spec: appsv1.DeploymentSpec{
-			Replicas: int32Ptr(1),
-			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					"name": q.Name(),
-				},
-			},
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						"name": q.Name(),
-					},
-				},
-				Spec: corev1.PodSpec{
-					ServiceAccountName: q.Name(),
-					Containers: []corev1.Container{
-						{
-							Command:         []string{q.Name()},
-							Name:            q.Name(),
-							Image:           q.Image(),
-							ImagePullPolicy: corev1.PullAlways,
-							Env: []corev1.EnvVar{
-								{
-									Name:      "WATCH_NAMESPACE",
-									ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"}},
-								},
-								{
-									Name:      "POD_NAME",
-									ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"}},
-								},
-								{
-									Name:  "OPERATOR_NAME",
-									Value: q.Name(),
-								},
-							},
-							Ports: []corev1.ContainerPort{
-								{
-									Name:          "metrics",
-									ContainerPort: 60000,
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-	_, err := q.kubeClient.AppsV1().Deployments(q.Namespace()).Create(dep)
-	if err != nil {
-		return fmt.Errorf("create qdr-operator deployment failed: %v", err)
-	}
-	return nil
 }
 
 func int32Ptr(i int32) *int32 { return &i }

--- a/pkg/framework/operators/supported.go
+++ b/pkg/framework/operators/supported.go
@@ -4,12 +4,15 @@ type OperatorType int
 
 const (
 	OperatorTypeQdr OperatorType = iota
-	OperatorTypeBase OperatorType = iota
 )
 
 var (
 	SupportedOperators = map[OperatorType]OperatorSetupBuilder{
-		OperatorTypeQdr: &QdrOperatorBuilder{},
-		OperatorTypeBase: &BaseOperatorBuilder{},
+		OperatorTypeQdr: &QdrOperatorBuilder{BaseOperatorBuilder{
+			image:        "quay.io/interconnectedcloud/qdr-operator",
+			operatorName: "qdr-operator",
+			keepCdrs:     true,
+			apiVersion:   "v1alpha1",
+		}},
 	}
 )

--- a/test/framework/setup.go
+++ b/test/framework/setup.go
@@ -1,8 +1,8 @@
 package framework
 
 import (
-	"github.com/rh-messaging/shipshape/pkg/framework"
 	"github.com/onsi/ginkgo"
+	"github.com/rh-messaging/shipshape/pkg/framework"
 )
 
 // Constants available for all test specs related with shipshape framework 
@@ -18,7 +18,8 @@ var (
 // Create the Framework instance to be used
 var _ = ginkgo.BeforeEach(func() {
 	// Setup the topology
-	Framework = framework.NewFramework(DeployName, framework.TestContext.GetContexts()[0])
+	builder := framework.NewFrameworkBuilder(DeployName)
+	Framework = builder.Build()
 }, 60)
 
 // After each test completes, run cleanup actions to save resources (otherwise resources will remain till


### PR DESCRIPTION
@mkrutov and @rvais here is an example of what I discussed with you guys today.
The `OperatorSetupBuilder` interface has been enhanced and we use the `BaseOperatorBuilder` as a "partial" implementation keeping `OperatorType()` as an abstract.

This way I have modified `QdrOperatorBuilder` to be "composed" by `BaseOperatorBuilder`, meaning it reuses all properties and methods from it. So if you look into `qdroperator.go`, I just had to implement `Build()` and `OperatorType()` methods.

With this in place, on the `supported.go` file the QdrOperatorBuilder instance can be easily customized to use a specific image or version, as needed.

The e2e tests (use: `make cluster-test`) are passing now. So feel free to review and so we can discuss tomorrow (or today for you guys).