### PR TITLE
Using Container TerminationMessageFallbackToLogsOnError Policy

### DIFF
--- a/pkg/framework/pod.go
+++ b/pkg/framework/pod.go
@@ -31,6 +31,7 @@ func NewContainerBuilder(name string, image string) *ContainerBuilder {
 	cb.c = v1.Container{}
 	cb.c.Name = name
 	cb.c.Image = image
+	cb.c.TerminationMessagePolicy = v1.TerminationMessageFallbackToLogsOnError
 	return cb
 }
 


### PR DESCRIPTION
Using this policy crashes are easily troubleshooted.
You can see the error in the pod termination message.