### PR TITLE
Add support for prepared yaml objects instead of yaml URLs

### DIFF
--- a/pkg/framework/operators/brokeroperator.go
+++ b/pkg/framework/operators/brokeroperator.go
@@ -33,13 +33,13 @@ func (b *BrokerOperatorBuilder) Build() (OperatorSetup, error) {
 	} else if broker.yamlURLs == nil {
 		baseImportPath := "https://raw.githubusercontent.com/rh-messaging/activemq-artemis-operator/master/deploy/"
 		broker.yamlURLs = []string{
-			baseImportPath + "service_account.yamls",
-			baseImportPath + "role.yamls",
-			baseImportPath + "role_binding.yamls",
-			baseImportPath + "crds/broker_v2alpha1_activemqartemis_crd.yamls",
-			baseImportPath + "crds/broker_v2alpha1_activemqartemisaddress_crd.yamls",
-			baseImportPath + "crds/broker_v2alpha1_activemqartemisscaledown_crd.yamls",
-			baseImportPath + "operator.yamls",
+			baseImportPath + "service_account.yaml",
+			baseImportPath + "role.yaml",
+			baseImportPath + "role_binding.yaml",
+			baseImportPath + "crds/broker_v2alpha1_activemqartemis_crd.yaml",
+			baseImportPath + "crds/broker_v2alpha1_activemqartemisaddress_crd.yaml",
+			baseImportPath + "crds/broker_v2alpha1_activemqartemisscaledown_crd.yaml",
+			baseImportPath + "operator.yaml",
 		}
 	}
 

--- a/pkg/framework/operators/brokeroperator.go
+++ b/pkg/framework/operators/brokeroperator.go
@@ -2,15 +2,15 @@ package operators
 
 import (
 	"fmt"
+	brokerclientset "github.com/rh-messaging/activemq-artemis-operator/pkg/client/clientset/versioned"
 	"github.com/rh-messaging/shipshape/pkg/framework/log"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	brokerclientset "github.com/rh-messaging/activemq-artemis-operator/pkg/client/clientset/versioned"
 )
 
 // Reusing BaseOperatorBuilder implementation and adding
 // the "abstract" method Build() and OperatorType()
-type BrokerOperatorBuilder struct{
+type BrokerOperatorBuilder struct {
 	BaseOperatorBuilder
 }
 
@@ -20,7 +20,7 @@ func (b *BrokerOperatorBuilder) Build() (OperatorSetup, error) {
 		return broker, err
 	}
 
-	if brokerclient, err := brokerclientset.NewForConfig(b.restConfig); err!= nil {
+	if brokerclient, err := brokerclientset.NewForConfig(b.restConfig); err != nil {
 		return broker, err
 	} else {
 		broker.brokerClient = brokerclient
@@ -28,16 +28,18 @@ func (b *BrokerOperatorBuilder) Build() (OperatorSetup, error) {
 
 	broker.customCommand = b.customCommand
 	// Setting up the defaults
-	baseImportPath := "https://raw.githubusercontent.com/rh-messaging/activemq-artemis-operator/master/deploy/"
-	if broker.yamls == nil {
-		broker.yamls = []string{
-			baseImportPath + "service_account.yaml",
-			baseImportPath + "role.yaml",
-			baseImportPath + "role_binding.yaml",
-			baseImportPath + "crds/broker_v2alpha1_activemqartemis_crd.yaml",
-			baseImportPath + "crds/broker_v2alpha1_activemqartemisaddress_crd.yaml",
-			baseImportPath + "crds/broker_v2alpha1_activemqartemisscaledown_crd.yaml",
-			baseImportPath + "operator.yaml",
+	if broker.yamls != nil {
+
+	} else if broker.yamlURLs == nil {
+		baseImportPath := "https://raw.githubusercontent.com/rh-messaging/activemq-artemis-operator/master/deploy/"
+		broker.yamlURLs = []string{
+			baseImportPath + "service_account.yamls",
+			baseImportPath + "role.yamls",
+			baseImportPath + "role_binding.yamls",
+			baseImportPath + "crds/broker_v2alpha1_activemqartemis_crd.yamls",
+			baseImportPath + "crds/broker_v2alpha1_activemqartemisaddress_crd.yamls",
+			baseImportPath + "crds/broker_v2alpha1_activemqartemisscaledown_crd.yamls",
+			baseImportPath + "operator.yamls",
 		}
 	}
 

--- a/pkg/framework/operators/operator.go
+++ b/pkg/framework/operators/operator.go
@@ -10,11 +10,12 @@ type OperatorSetupBuilder interface {
 	WithNamespace(namespace string) OperatorSetupBuilder
 	WithImage(image string) OperatorSetupBuilder
 	WithCommand(command string) OperatorSetupBuilder
-	WithYamls(yamls []string) OperatorSetupBuilder
-	AddYaml(yaml string) OperatorSetupBuilder
+	WithYamlURLs(yamls []string) OperatorSetupBuilder
+	AddYamlURL(yaml string) OperatorSetupBuilder
 	WithOperatorName(name string) OperatorSetupBuilder
 	KeepCdr(keepCdrs bool) OperatorSetupBuilder
 	WithApiVersion(apiVersion string) OperatorSetupBuilder
+	WithYamls(yamls [][]byte) OperatorSetupBuilder
 	Build() (OperatorSetup, error)
 	OperatorType() OperatorType
 }

--- a/pkg/framework/operators/qdroperator.go
+++ b/pkg/framework/operators/qdroperator.go
@@ -10,7 +10,7 @@ import (
 
 // Reusing BaseOperatorBuilder implementation and adding
 // the "abstract" method Build() and OperatorType()
-type QdrOperatorBuilder struct{
+type QdrOperatorBuilder struct {
 	BaseOperatorBuilder
 }
 
@@ -29,15 +29,15 @@ func (q *QdrOperatorBuilder) Build() (OperatorSetup, error) {
 
 	// Setting up the defaults
 	baseImportPath := "https://raw.githubusercontent.com/interconnectedcloud/qdr-operator/master/deploy/"
-	if qdr.yamls == nil {
-		qdr.yamls = []string{
-			baseImportPath + "service_account.yaml",
-			baseImportPath + "role.yaml",
-			baseImportPath + "role_binding.yaml",
-			baseImportPath + "cluster_role.yaml",
-			baseImportPath + "cluster_role_binding.yaml",
-			baseImportPath + "crds/interconnectedcloud_v1alpha1_interconnect_crd.yaml",
-			baseImportPath + "operator.yaml",
+	if qdr.yamlURLs == nil {
+		qdr.yamlURLs = []string{
+			baseImportPath + "service_account.yamls",
+			baseImportPath + "role.yamls",
+			baseImportPath + "role_binding.yamls",
+			baseImportPath + "cluster_role.yamls",
+			baseImportPath + "cluster_role_binding.yamls",
+			baseImportPath + "crds/interconnectedcloud_v1alpha1_interconnect_crd.yamls",
+			baseImportPath + "operator.yamls",
 		}
 	}
 
@@ -50,7 +50,7 @@ func (q *QdrOperatorBuilder) OperatorType() OperatorType {
 
 type QdrOperator struct {
 	BaseOperator
-	qdrClient  qdrclientset.Interface
+	qdrClient qdrclientset.Interface
 }
 
 func (q *QdrOperator) Namespace() string {

--- a/pkg/framework/operators/qdroperator.go
+++ b/pkg/framework/operators/qdroperator.go
@@ -31,13 +31,13 @@ func (q *QdrOperatorBuilder) Build() (OperatorSetup, error) {
 	baseImportPath := "https://raw.githubusercontent.com/interconnectedcloud/qdr-operator/master/deploy/"
 	if qdr.yamlURLs == nil {
 		qdr.yamlURLs = []string{
-			baseImportPath + "service_account.yamls",
-			baseImportPath + "role.yamls",
-			baseImportPath + "role_binding.yamls",
-			baseImportPath + "cluster_role.yamls",
-			baseImportPath + "cluster_role_binding.yamls",
-			baseImportPath + "crds/interconnectedcloud_v1alpha1_interconnect_crd.yamls",
-			baseImportPath + "operator.yamls",
+			baseImportPath + "service_account.yaml",
+			baseImportPath + "role.yaml",
+			baseImportPath + "role_binding.yaml",
+			baseImportPath + "cluster_role.yaml",
+			baseImportPath + "cluster_role_binding.yaml",
+			baseImportPath + "crds/interconnectedcloud_v1alpha1_interconnect_crd.yaml",
+			baseImportPath + "operator.yaml",
 		}
 	}
 


### PR DESCRIPTION
We need to modify few things in downstream builds, so passing yaml URLs doesn't always cover all the cases. Add support for passing []byte's containing YAMLs to the framework.

As a side note, I really don't like that we have to convert to json internally, but use yamls externally. 