### PR TITLE
fix pod-security issue on clients pods

### DIFF
--- a/pkg/api/client/amqp/qeclients/factoryreceiver.go
+++ b/pkg/api/client/amqp/qeclients/factoryreceiver.go
@@ -1,9 +1,10 @@
 package qeclients
 
 import (
+	"sync"
+
 	"github.com/rh-messaging/shipshape/pkg/api/client/amqp"
 	"github.com/rh-messaging/shipshape/pkg/framework"
-	"sync"
 )
 
 type AmqpQEReceiverBuilder struct {


### PR DESCRIPTION
Given the last change on openshift 4.12 / kubernetes related to the pod security there is a need to run the pod/container without privileges.