### PR TITLE
fix qe client to pod to set the userid to run

### DIFF
--- a/pkg/framework/pod.go
+++ b/pkg/framework/pod.go
@@ -29,8 +29,10 @@ func NewPodBuilder(name string, namespace string) *PodBuilder {
 	pb.pod.Namespace = namespace
 	pb.pod.Status = v1.PodStatus{}
 	pb.pod.Spec = v1.PodSpec{}
+	userId := int64(1000)
 	pb.pod.Spec.SecurityContext = &v1.PodSecurityContext{
 		RunAsNonRoot: &[]bool{true}[0],
+		RunAsUser:    &userId,
 		SeccompProfile: &v1.SeccompProfile{
 			Type: v1.SeccompProfileTypeRuntimeDefault,
 		},


### PR DESCRIPTION
Running the QE client pod on OCP 4.10 is falling as the QE Client image sets the user as a non-numeric one and when running the pod as RunAsNonRoot it breaks the execution. This PR adds the RunAsUser in the QE client pod to be execute with UID 1000 which is the UID of cli-java user in the quay.io/messaging/cli-java image.

On OCP 4.11 and OCP 4.12 it is not happening and set the RunAsUser as 1000 does not have any impact on my testing.

For reference, here is the OCP 4.10 error message:
```
Successfully pulled image "quay.io/messaging/cli-java" in 305.912233ms
1s          Warning   Failed              pod/sender                                  Error: container has runAsNonRoot and image has non-numeric user (cli-java), cannot verify user is non-root (pod: "sender_shipshape-broker-vuirn(fff849f2-b979-4792-b31c-15e97da7febc)", container: sender)
```