### PR TITLE
use SecCompProfile on client based on server ver

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/google/go-cmp v0.5.5 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/google/uuid v1.1.2 // indirect
+	github.com/hashicorp/go-version v1.6.0 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -429,6 +429,8 @@ github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerX
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
+github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
+github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=

--- a/pkg/api/client/amqp/qeclients/factoryreceiver.go
+++ b/pkg/api/client/amqp/qeclients/factoryreceiver.go
@@ -41,7 +41,7 @@ func (a *AmqpQEReceiverBuilder) WithCount(count int) *AmqpQEReceiverBuilder {
 
 func (a *AmqpQEReceiverBuilder) Build() (*AmqpQEClientCommon, error) {
 	// Preparing Pod, Container (commands and args) and etc
-	podBuilder := framework.NewPodBuilder(a.receiver.Name, a.receiver.Context.Namespace)
+	podBuilder := framework.NewPodBuilder(a.receiver.Name, a.receiver.Context.Namespace, a.receiver.Context.ServerVersion)
 	podBuilder.AddLabel("amqp-client-impl", QEClientImageMap[a.receiver.Implementation].Name)
 	podBuilder.RestartPolicy("Never")
 

--- a/pkg/api/client/amqp/qeclients/factorysender.go
+++ b/pkg/api/client/amqp/qeclients/factorysender.go
@@ -1,9 +1,10 @@
 package qeclients
 
 import (
+	"sync"
+
 	"github.com/rh-messaging/shipshape/pkg/api/client/amqp"
 	"github.com/rh-messaging/shipshape/pkg/framework"
-	"sync"
 )
 
 const (
@@ -60,7 +61,7 @@ func (a *AmqpQESenderBuilder) MessageContentFromFile(configMapName string, filen
 
 func (a *AmqpQESenderBuilder) Build() (*AmqpQEClientCommon, error) {
 	// Preparing Pod, Container (commands and args), Volumes and etc
-	podBuilder := framework.NewPodBuilder(a.sender.Name, a.sender.Context.Namespace)
+	podBuilder := framework.NewPodBuilder(a.sender.Name, a.sender.Context.Namespace, a.sender.Context.ServerVersion)
 	podBuilder.AddLabel("amqp-client-impl", QEClientImageMap[a.sender.Implementation].Name)
 	podBuilder.RestartPolicy("Never")
 


### PR DESCRIPTION
Use the SecCompProfile as RuntimeDefault on ocp < 4.10 (kubernetes < 1.23) is causing the client pod to do not have enough permission to run java client.
This PR changes the clients pod creating to include the SecComProfile only on ocp >= 4.10 (kubernetes >= 1.23)